### PR TITLE
TD-1542 - Fiks pypi publish

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -6,6 +6,13 @@ on:
       version:
         description: "Version to be published"
         required: true
+        default: "0.0.1"
+        type: string
+
+
+permissions:
+  id-token: write # Required for Octo STS
+
 
 jobs:
   publish:
@@ -15,17 +22,20 @@ jobs:
       run:
         working-directory: dask-felleskomponenter
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+        id: octo-sts
         with:
+          scope: kartverket/dask-felleskomponenter
+          identity: "dask-felleskomponenter"
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
           fetch-depth: 0
 
-      - name: Get the current branch name
-        id: vars
-        run: echo "BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
-
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
@@ -33,27 +43,25 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install setuptools wheel twine build
-
-      - name: Configure Git
-        run: |
-          git config --local user.name "GitHub Actions"
-          git config --local user.email "actions@github.com"
 
       - name: Bump version in setup.py
         run: |
           sed -i "s/version=\"[^\"]*\"/version=\"${{ github.event.inputs.version }}\"/" setup.py
-          git add setup.py
-          git commit -m "Bump dask-felleskomponenter PyPI package version to ${{ github.event.inputs.version }}"
-          git push origin ${{ env.BRANCH_NAME }}
+
+      - name: Commit changes to repo
+        run: |
+          git config --local user.name "GitHub Actions"
+          git config --local user.email "noreply@kartverket.no"
+          git commit -am "Bump dask-felleskomponenter PyPI package version to ${{ github.event.inputs.version }}"
+          git push
 
       - name: Build the package
         run: |
           python3 -m build
 
-      - name: Publish to PyPI
-        run: |
-          python3 -m twine upload dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      # - name: Publish to PyPI
+      #   run: |
+      #     python3 -m twine upload dist/*
+      #   env:
+      #     TWINE_USERNAME: __token__
+      #     TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,9 +18,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     environment: pypi-publish
-    defaults:
-      run:
-        working-directory: dask-felleskomponenter
     steps:
       - uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
         id: octo-sts

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -48,12 +48,15 @@ jobs:
         run: |
           sed -i "s/version=\"[^\"]*\"/version=\"${{ github.event.inputs.version }}\"/" setup.py
 
-      - name: Commit changes to repo
-        run: |
-          git config --local user.name "GitHub Actions"
-          git config --local user.email "noreply@kartverket.no"
-          git commit -am "Bump dask-felleskomponenter PyPI package version to ${{ github.event.inputs.version }}"
-          git push
+      - name: See github ref
+        run: echo "${{ github.ref }}"
+
+      # - name: Commit changes to repo
+      #   run: |
+      #     git config --local user.name "GitHub Actions"
+      #     git config --local user.email "noreply@kartverket.no"
+      #     git commit -am "Bump dask-felleskomponenter PyPI package version to ${{ github.event.inputs.version }}"
+      #     git push
 
       - name: Build the package
         run: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -45,15 +45,12 @@ jobs:
         run: |
           sed -i "s/version=\"[^\"]*\"/version=\"${{ github.event.inputs.version }}\"/" setup.py
 
-      - name: See github ref
-        run: echo "${{ github.ref }}"
-
-      # - name: Commit changes to repo
-      #   run: |
-      #     git config --local user.name "GitHub Actions"
-      #     git config --local user.email "noreply@kartverket.no"
-      #     git commit -am "Bump dask-felleskomponenter PyPI package version to ${{ github.event.inputs.version }}"
-      #     git push
+      - name: Commit changes to repo
+        run: |
+          git config --local user.name "GitHub Actions"
+          git config --local user.email "noreply@kartverket.no"
+          git commit -am "Bump dask-felleskomponenter PyPI package version to ${{ github.event.inputs.version }}"
+          git push
 
       - name: Build the package
         run: |

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -56,9 +56,9 @@ jobs:
         run: |
           python3 -m build
 
-      # - name: Publish to PyPI
-      #   run: |
-      #     python3 -m twine upload dist/*
-      #   env:
-      #     TWINE_USERNAME: __token__
-      #     TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+      - name: Publish to PyPI
+        run: |
+          python3 -m twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ command
 pip install -r requirements.txt
 ```
 
-### Formatering av kode
+### Code formatting
 
-Python-kodebasen valideres med [Black](https://black.readthedocs.io/en/stable/) i en Github Action. Det betyr at din pull request kommer til å feile hvis koden er feilformatert, så automatisk formatering med Black bør settes opp lokalt i din editor.
+The python code is validated against [Black](https://black.readthedocs.io/en/stable/) formatting in a Github Action. This means that your pull request will fail if the code isn't formatted according to Black standards. It is therefore suggested to enable automatic formatting using Black in your IDE.
 
 ## Bulding and publishing of package
 
@@ -29,11 +29,10 @@ One member of Team DASK needs to approve the workflow run before it starts.
 
 - Remove old dist-folder, from last time you published
 - Update version in `setup.py`, for instance `0.0.7`->`0.0.8`
-- Add change info to CHANGES.txt
 - (Run `pip install -r requirements.txt` if you haven't done that earlier)
 - Run `python3 -m build` (and wait some minutes...)
-- Verity that dist contains a package with the new version in the package name.
-- Run `python3 -m twine upload dist/*` to upload to pypi
+- Verify that dist contains a package with the new version in the package name.
+- Run `python3 -m twine upload dist/*` to upload to PyPi
 
 ### To upload to PyPi test
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 build
 black
-twine
 coverage
 requests
-databricks-connect
 setuptools
+twine

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ packages = setuptools.find_packages(where="src")
 
 setuptools.setup(
     name="dask-felleskomponenter",
-    version="0.0.1",
+    version="0.1.8",
     author="Dataplattform@Statens Kartverk",
     author_email="dataplattform@kartverket.no",
     description="Felleskomponenter på DASK",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ packages = setuptools.find_packages(where="src")
 
 setuptools.setup(
     name="dask-felleskomponenter",
-    version="0.1.8",
+    version="0.0.1",
     author="Dataplattform@Statens Kartverk",
     author_email="dataplattform@kartverket.no",
     description="Felleskomponenter på DASK",


### PR DESCRIPTION
### Beskrivelse

Legger inn octo-sts i pypi-publish action for å kunne commite til repoet underveis i actionen
Testet i føgende run som gjør at utenom å pushe ny versjon til pypi: https://github.com/kartverket/dask-felleskomponenter/actions/runs/15185748024/job/42705605825
Se følgende commit som viser at actionen får commite endringer: https://github.com/kartverket/dask-felleskomponenter/commit/53f077565140619f66b2af4ef08c443478792736