### PR TITLE
fix error when deploying package

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -66,8 +66,12 @@ jobs:
         run: |
           git config --local user.name "GitHub Actions"
           git config --local user.email "noreply@kartverket.no"
-          git commit -am "Bump dask-felleskomponenter PyPI package version to ${{ github.event.inputs.version }}"
-          git push
+          if [[ -n $(git status --porcelain) ]]; then
+            git commit -am "Bump dask-felleskomponenter PyPI package version to ${{ github.event.inputs.version }}"
+            git push
+          else
+            echo "Ingen endringer detektert. Skipper commit og push."
+          fi
 
       - name: Build the package
         run: |


### PR DESCRIPTION
If a build have allready run and updated repo, publish to pypi is not run, since dependent action task failes.