### PR TITLE
Konfigurerbar ref for publisering

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -17,6 +17,10 @@ on:
         description: "Version-number to be published. Setting this input-value will update the version-field in pyproject.toml, and the changes will be pushed to Github. If omitted, the value from pyproject.toml will be used."
         required: false
         type: string
+      ref:
+        description: "Git ref to checkout for building the package. Defaults to main."
+        required: false
+        type: string
 
 permissions:
   id-token: write # Required for Octo STS
@@ -38,6 +42,7 @@ jobs:
         with:
           token: ${{ steps.octo-sts.outputs.token }}
           fetch-depth: 0
+          ref: ${{ github.event.inputs.ref || 'main'}}
 
       - name: Install Poetry
         run: pipx install poetry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = "dask-felleskomponenter"
-version = "0.2.0"
+version = "0.2.1-alpha"
 authors = [
   { name="Dataplattform@Statens Kartverk", email="dataplattform@kartverket.no" },
 ]


### PR DESCRIPTION
For å teste installerbart bibliotek før det egentlig er ferdig kan det være fint å publisere noe halvferdig til testpypi.
Da kan det også være kjekt å få lov til å gi inn navnet på en branch som det skal bygges utifra, så man slipper å måtte merge til main for å teste noe. 
Denne branchen gjør det mulig. 